### PR TITLE
Do not expand hostnames which contains puncations marks.

### DIFF
--- a/util.py
+++ b/util.py
@@ -325,7 +325,11 @@ def resolve_ip(ip: str) -> str:
 
 def resolve_input_name(name: str) -> str:
     """Tries to find the named host. Raises an exception if not."""
-    hostname = clean_hostname(name.lower())
+    if "." in name:
+        hostname = name
+    else:
+        hostname = clean_hostname(name)
+
     url = "http://{}:{}/hosts/?name={}".format(
         conf["server_ip"],
         conf["server_port"],

--- a/util.py
+++ b/util.py
@@ -325,6 +325,7 @@ def resolve_ip(ip: str) -> str:
 
 def resolve_input_name(name: str) -> str:
     """Tries to find the named host. Raises an exception if not."""
+    name = name.lower()
     if "." in name:
         hostname = name
     else:


### PR DESCRIPTION
Might later require an explicit trailing dot, to distinguish
"sub.sub2" which should be interpreted as "sub.sub2.domain.in.conf"
from the fqdn "sub.tld".

Resolves #62.