### PR TITLE
In the API the field orderv was renamed to order. So follow up API.

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1694,7 +1694,7 @@ class Host(CommandBase):
 
         data = {
             "preference": int(pref),
-            "orderv": int(order),
+            "order": int(order),
             "flag": flag,
             "service": service,
             "regex": regex,

--- a/util.py
+++ b/util.py
@@ -681,7 +681,7 @@ def print_naptr(naptr: dict, host_name: str, padding: int = 14) -> None:
         padding,
         host_name,
         naptr["preference"],
-        naptr["orderv"],
+        naptr["order"],
         naptr["flag"],
         naptr["service"],
         naptr["regex"] or "",


### PR DESCRIPTION
Resolves #77.